### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Wiki should be detail, up to date and well structured. It should be easy to find
 - [aws/aws-parallelcluster](https://github.com/aws/aws-parallelcluster/wiki)
 - [facebook/hhvm](https://github.com/facebook/hhvm/wiki)
 - [thinkaurelius/titan](https://github.com/thinkaurelius/titan/wiki)
-- [guard/guard](https://github.com/guard/guard/wiki/Guard-2.10.3-exits-when-Guardfile-is-changed)
+- [guard/guard](https://github.com/guard/guard/wiki)
 - [apple/foundationdb](https://github.com/apple/foundationdb/wiki)
 - [google/guava](https://github.com/google/guava/wiki)
 - [hyperledger/cacti](https://github.com/hyperledger/cacti/wiki)


### PR DESCRIPTION
The wiki link for guard was redirecting to some other sub-heading instead of the home page. 

I've updated the link to redirect to the wiki homepage.